### PR TITLE
Extend ctor support for collections

### DIFF
--- a/ExpressMapper NET40/DestinationTypeMapper.cs
+++ b/ExpressMapper NET40/DestinationTypeMapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/ExpressMapper NET40/MappingServiceProvider.cs
+++ b/ExpressMapper NET40/MappingServiceProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -441,8 +441,8 @@ namespace ExpressMapper
 
             var destExp = Expression.Property(contextVarExp, "Destination");
             var destAssignedExp = Expression.Assign(destExp, dstTypedExp);
-            
-            
+
+
             //var destinationAssignedExp = Expression.Assign(destinationExpression, dstTypedExp);
 
             var mapCall = Expression.Call(genVariable, methodInfo, contextVarExp);

--- a/ExpressMapper.Tests NET40/CollectionTests.cs
+++ b/ExpressMapper.Tests NET40/CollectionTests.cs
@@ -31,6 +31,64 @@ namespace ExpressMapper.Tests
         }
 
         [Test]
+        public void AutoMemberMap_ToNonGenericListInherited() {
+          Mapper.Register<TestModel, TestViewModel>();
+          Mapper.Register<Size, SizeViewModel>();
+          Mapper.Register<Country, CountryViewModel>();
+          Mapper.Compile();
+
+          var testData = Functional.CollectionAutoMemberMap();
+
+          var result = Mapper.Map<List<TestModel>, NonGenericCollectionInhertedFromList>( testData.Key );
+
+          Assert.AreEqual( result.Count, testData.Value.Count );
+
+          for ( var i = 0; i < result.Count; i++ ) {
+            Assert.AreEqual( result[i], testData.Value[i] );
+          }
+        }
+
+        [Test]
+        public void AutoMemberMap_ToLinkedList() {
+          Mapper.Register<TestModel, TestViewModel>();
+          Mapper.Register<Size, SizeViewModel>();
+          Mapper.Register<Country, CountryViewModel>();
+          Mapper.Compile();
+
+          var testData = Functional.CollectionAutoMemberMap();
+
+          var result = Mapper.Map<List<TestModel>, LinkedList<TestViewModel>>( testData.Key );
+
+          Assert.AreEqual( result.Count, testData.Value.Count );
+
+          var resultList = result.ToList();
+
+          for ( var i = 0; i < resultList.Count; i++ ) {
+            Assert.AreEqual( resultList[i], testData.Value[i] );
+          }
+        }
+
+        [Test]
+        public void AutoMemberMap_ToNonGenericEnumerableInherited() {
+          Mapper.Register<TestModel, TestViewModel>();
+          Mapper.Register<Size, SizeViewModel>();
+          Mapper.Register<Country, CountryViewModel>();
+          Mapper.Compile();
+
+          var testData = Functional.CollectionAutoMemberMap();
+
+          var result = Mapper.Map<List<TestModel>, NonGenericCollectionImplementingIEnumerable>( testData.Key );
+
+          var resultList = result.ToList();
+
+          Assert.AreEqual( resultList.Count, testData.Value.Count );
+
+          for ( var i = 0; i < resultList.Count; i++ ) {
+            Assert.AreEqual( resultList[i], testData.Value[i] );
+          }
+        }
+
+        [Test]
         public void DirectDynamicCollectionMapTest()
         {
             var testData = Functional.CollectionAutoMemberMap();

--- a/ExpressMapper.Tests.Model/ExpressMapper.Tests.Model.csproj
+++ b/ExpressMapper.Tests.Model/ExpressMapper.Tests.Model.csproj
@@ -58,6 +58,8 @@
     <Compile Include="Models\FashionProduct.cs" />
     <Compile Include="Models\ItemModel.cs" />
     <Compile Include="Models\Mail.cs" />
+    <Compile Include="Models\NonGenericCollectionImplementingIEnumerable.cs" />
+    <Compile Include="Models\NonGenericCollectionInhertedFromList.cs" />
     <Compile Include="Models\Organization.cs" />
     <Compile Include="Models\Person.cs" />
     <Compile Include="Models\Product.cs" />

--- a/ExpressMapper.Tests.Model/Models/NonGenericCollectionImplementingIEnumerable.cs
+++ b/ExpressMapper.Tests.Model/Models/NonGenericCollectionImplementingIEnumerable.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+using ExpressMapper.Tests.Model.ViewModels;
+
+namespace ExpressMapper.Tests.Model.Models {
+  public class NonGenericCollectionImplementingIEnumerable: IEnumerable<TestViewModel> {
+    private readonly List<TestViewModel> _models;
+
+    public NonGenericCollectionImplementingIEnumerable( IEnumerable<TestViewModel> models ) {
+      _models = models.ToList();
+    }
+
+    public IEnumerator<TestViewModel> GetEnumerator() {
+      return _models.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+      return GetEnumerator();
+    }
+  }
+}

--- a/ExpressMapper.Tests.Model/Models/NonGenericCollectionInhertedFromList.cs
+++ b/ExpressMapper.Tests.Model/Models/NonGenericCollectionInhertedFromList.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+using ExpressMapper.Tests.Model.ViewModels;
+
+namespace ExpressMapper.Tests.Model.Models {
+  public class NonGenericCollectionInhertedFromList: List<TestViewModel> {
+
+    public NonGenericCollectionInhertedFromList( IEnumerable<TestViewModel> models ) : base( models ) { }
+  }
+}


### PR DESCRIPTION
This allows mapping to destination collection types that themselves have no generic type arguments, but which do implement/Inherit say IEnumerable<T> or List<T>.

It also clears up some code in ConvertCollection.