### PR TITLE
Fixed mapping for overriden properties.

### DIFF
--- a/ExpressMapper NET40/MemberConfiguration.cs
+++ b/ExpressMapper NET40/MemberConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace ExpressMapper
 {
@@ -57,7 +58,7 @@ namespace ExpressMapper
                 throw new Exception("MemberExpression should return one of the properties of destination class");
             }
 
-            var propertyInfo = typeof(TN).GetProperty(memberExpression.Member.Name);
+            var propertyInfo = memberExpression.Member as PropertyInfo;
 
             if (propertyInfo != null && !propertyInfo.CanWrite || (propertyInfo != null && propertyInfo.CanWrite && !propertyInfo.GetSetMethod(true).IsPublic))
             {

--- a/ExpressMapper NET40/MemberConfiguration.cs
+++ b/ExpressMapper NET40/MemberConfiguration.cs
@@ -82,7 +82,7 @@ namespace ExpressMapper
                 throw new Exception("MemberExpression should return one of the properties of destination class");
             }
 
-            var propertyInfo = typeof(TN).GetProperty(memberExpression.Member.Name);
+            var propertyInfo = memberExpression.Member as PropertyInfo;
 
             if (propertyInfo != null && !propertyInfo.CanWrite && !propertyInfo.GetSetMethod(true).IsPublic)
             {

--- a/ExpressMapper.Tests NET40/BasicTests.cs
+++ b/ExpressMapper.Tests NET40/BasicTests.cs
@@ -231,6 +231,31 @@ namespace ExpressMapper.Tests
         }
 
         [Test]
+        public void HiddenInheritedMemberMap()
+        {
+            Mapper.Register<SpecialPerson, SpecialPersonViewModel>();
+
+            var mapConfig = Mapper.Register<SpecialGift, SpecialGiftViewModel>();
+            MapBaseMember(mapConfig);
+            mapConfig.Member(src => src.Recipient, dst => dst.Recipient);
+
+            Mapper.Compile();
+
+            var srcDst = Functional.HiddenInheritedMemberMap();
+
+            var result = Mapper.Map<SpecialGift, SpecialGiftViewModel>(srcDst.Key);
+
+            Assert.AreEqual(result, srcDst.Value);
+        }
+
+        private void MapBaseMember<T, TN>(IMemberConfiguration<T,TN> mapConfig) 
+            where T : Gift
+            where TN : GiftViewModel
+        {
+            mapConfig.Member(src => src.Recipient, dst => dst.Recipient);
+        }
+
+        [Test]
         public void ManualConstantMemberMap()
         {
             Mapper.Register<Size, SizeViewModel>()

--- a/ExpressMapper.Tests.Model/ExpressMapper.Tests.Model.csproj
+++ b/ExpressMapper.Tests.Model/ExpressMapper.Tests.Model.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Models\Employee.cs" />
     <Compile Include="Models\Engine.cs" />
     <Compile Include="Models\FashionProduct.cs" />
+    <Compile Include="Models\Gift.cs" />
     <Compile Include="Models\ItemModel.cs" />
     <Compile Include="Models\Mail.cs" />
     <Compile Include="Models\NonGenericCollectionImplementingIEnumerable.cs" />
@@ -65,6 +66,7 @@
     <Compile Include="Models\Product.cs" />
     <Compile Include="Models\ProductOption.cs" />
     <Compile Include="Models\Size.cs" />
+    <Compile Include="Models\SpecialPerson.cs" />
     <Compile Include="Models\Structs\Feature.cs" />
     <Compile Include="Models\Structs\Item.cs" />
     <Compile Include="Models\SubItem.cs" />
@@ -78,6 +80,7 @@
     <Compile Include="Models\TripCatalog.cs" />
     <Compile Include="Models\Unit.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Models\SpecialGift.cs" />
     <Compile Include="ViewModels\AddressViewModel.cs" />
     <Compile Include="ViewModels\BookingViewModel.cs" />
     <Compile Include="ViewModels\BrandViewModel.cs" />
@@ -90,6 +93,7 @@
     <Compile Include="ViewModels\EmployeeViewModel.cs" />
     <Compile Include="ViewModels\EngineViewModel.cs" />
     <Compile Include="ViewModels\FashionProductViewModel.cs" />
+    <Compile Include="ViewModels\GiftViewModel.cs" />
     <Compile Include="ViewModels\ItemModelViewModel.cs" />
     <Compile Include="ViewModels\MailViewModel.cs" />
     <Compile Include="ViewModels\OrganizationViewModel.cs" />
@@ -97,6 +101,8 @@
     <Compile Include="ViewModels\ProductOptionViewModel.cs" />
     <Compile Include="ViewModels\ProductViewModel.cs" />
     <Compile Include="ViewModels\SizeViewModel.cs" />
+    <Compile Include="ViewModels\SpecialGiftViewModel.cs" />
+    <Compile Include="ViewModels\SpecialPersonViewModel.cs" />
     <Compile Include="ViewModels\Structs\FeatureViewModel.cs" />
     <Compile Include="ViewModels\Structs\ItemViewModel.cs" />
     <Compile Include="ViewModels\SubItemViewModel.cs" />

--- a/ExpressMapper.Tests.Model/Generator/Functional.cs
+++ b/ExpressMapper.Tests.Model/Generator/Functional.cs
@@ -1172,6 +1172,42 @@ namespace ExpressMapper.Tests.Model.Generator
             return keyValuePair;
         }
 
+        public static KeyValuePair<SpecialGift, SpecialGiftViewModel> HiddenInheritedMemberMap()
+        {
+            var newGuid = Guid.NewGuid();
+            var otherGuid = Guid.NewGuid();
+            var keyValuePair = new KeyValuePair<SpecialGift, SpecialGiftViewModel>
+                (
+                new SpecialGift
+                {
+                    Id = newGuid,
+                    Name = "Vase",
+                    Recipient = new SpecialPerson
+                    {
+                        Name = "Mark",
+                        AffectionLevel = 10,
+                        Id = otherGuid,
+                        IsOrganization = false,
+                        IsPerson = true
+                    }
+                },
+                new SpecialGiftViewModel
+                {
+                    Id = newGuid,
+                    Name = "Vase",
+                    Recipient = new SpecialPersonViewModel
+                    {
+                        Name = "Mark",
+                        AffectionLevel = 10,
+                        Id = otherGuid,
+                        IsOrganization = false,
+                        IsPerson = true
+                    }
+                }
+                );
+            return keyValuePair;
+        }
+
         public static KeyValuePair<Size, SizeViewModel> InstantiateMap()
         {
             var newGuid = Guid.NewGuid();

--- a/ExpressMapper.Tests.Model/Models/Gift.cs
+++ b/ExpressMapper.Tests.Model/Models/Gift.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ExpressMapper.Tests.Model.Models
+{
+    public class Gift
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+
+        public Person Recipient { get; set; }
+    }
+}

--- a/ExpressMapper.Tests.Model/Models/SpecialGift.cs
+++ b/ExpressMapper.Tests.Model/Models/SpecialGift.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ExpressMapper.Tests.Model.Models
+{
+    public class SpecialGift : Gift
+    {
+        public new SpecialPerson Recipient { get; set; }
+    }
+}

--- a/ExpressMapper.Tests.Model/Models/SpecialPerson.cs
+++ b/ExpressMapper.Tests.Model/Models/SpecialPerson.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ExpressMapper.Tests.Model.Models
+{
+    public class SpecialPerson : Person
+    {
+        public int AffectionLevel;
+    }
+}

--- a/ExpressMapper.Tests.Model/ViewModels/GiftViewModel.cs
+++ b/ExpressMapper.Tests.Model/ViewModels/GiftViewModel.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ExpressMapper.Tests.Model.ViewModels
+{
+    public class GiftViewModel
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+
+        public PersonViewModel Recipient { get; set; }
+
+        public bool Equals(GiftViewModel other)
+        {
+            return Id == other.Id && Name == other.Name && (Recipient == null || Recipient.Equals(other.Recipient));
+        }
+    }
+}

--- a/ExpressMapper.Tests.Model/ViewModels/SpecialGiftViewModel.cs
+++ b/ExpressMapper.Tests.Model/ViewModels/SpecialGiftViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace ExpressMapper.Tests.Model.ViewModels
+{
+    public class SpecialGiftViewModel : GiftViewModel, IEquatable<SpecialGiftViewModel>
+    {
+        public new SpecialPersonViewModel Recipient { get; set; }
+
+        public bool Equals(SpecialGiftViewModel other)
+        {
+            return Recipient.Equals(other.Recipient) && base.Equals(other);
+        }
+    }
+}

--- a/ExpressMapper.Tests.Model/ViewModels/SpecialPersonViewModel.cs
+++ b/ExpressMapper.Tests.Model/ViewModels/SpecialPersonViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ExpressMapper.Tests.Model.ViewModels
+{
+    public class SpecialPersonViewModel : PersonViewModel
+    {
+        public int AffectionLevel { get; set; }
+
+        public bool Equals(SpecialPersonViewModel other)
+        {
+            return base.Equals(other) && AffectionLevel == other.AffectionLevel;
+        }
+    }
+}

--- a/ExpressMapper.Tests.Projections/ExpressMapper.Tests.Projections.csproj
+++ b/ExpressMapper.Tests.Projections/ExpressMapper.Tests.Projections.csproj
@@ -112,9 +112,6 @@
       <DependentUpon>201511050542223_Initial.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!--<Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/ExpressMapper.Tests.Projections/ExpressMapper.Tests.Projections.csproj
+++ b/ExpressMapper.Tests.Projections/ExpressMapper.Tests.Projections.csproj
@@ -112,6 +112,9 @@
       <DependentUpon>201511050542223_Initial.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!--<Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">


### PR DESCRIPTION
I detected a problem when trying to map an overriden property in a child class. The problem is that GetProperty method throws an Exception when trying to find the Property by name because it is defined in the parent and in the child classes, it's ambiguous.

The proposed solution is to just use the ´memberExpression.Member´ as the PropertyInfo.

All tests were run without problems.