### PR TITLE
Fix V3001

### DIFF
--- a/ExpressMapper.Tests.Model NETCORE/ViewModels/ProductViewModel.cs
+++ b/ExpressMapper.Tests.Model NETCORE/ViewModels/ProductViewModel.cs
@@ -27,7 +27,7 @@ namespace ExpressMapper.Tests.Model.ViewModels
             }
 
             return Id == other.Id && Name == other.Name && Description == other.Description && optionsEquals &&
-                   CreatedOn == other.CreatedOn && WarehouseOn == other.WarehouseOn && Ean == Ean &&
+                   CreatedOn == other.CreatedOn && WarehouseOn == other.WarehouseOn && Ean == other.Ean &&
                    OptionalGender == other.OptionalGender &&
                    ((Brand == null && other.Brand == null) || Brand.Equals(other.Brand)) &&
                    ((Supplier == null && other.Supplier == null) || Supplier.Equals(other.Supplier));


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- There are identical sub-expressions 'Ean' to the left and to the right of the '==' operator. ExpressMapper.Tests.Model NETCORE ProductViewModel.cs 30